### PR TITLE
Remove leading space in PLATFORM_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,7 +405,7 @@ endif(ALLEGRO_LEGACY_WINDOWS)
 list(APPEND PLATFORM_LIBS ${ALLEGRO_5_LIBRARY} ${ALLEGRO_5_AUDIO_LIBRARY})
 if(APPLE)
 	list(APPEND PLATFORM_LIBS ${ALLEGRO_5_MAIN_LIBRARY})
-	list(APPEND PLATFORM_LIBS " -framework OpenGL -framework OpenAL -framework AudioToolbox -framework Cocoa -framework IOKit -framework CoreVideo")
+	list(APPEND PLATFORM_LIBS "-framework OpenGL -framework OpenAL -framework AudioToolbox -framework Cocoa -framework IOKit -framework CoreVideo")
 endif()
 
 #-----------------------------------------------------------------------------#


### PR DESCRIPTION
Fixes this error:

```
CMake Error at cmake/Common.cmake:4 (add_library):
  Target "allegro" links to item " -framework OpenGL -framework OpenAL
  -framework AudioToolbox -framework Cocoa -framework IOKit -framework
  CoreVideo" which has leading or trailing whitespace.  This is now an error
  according to policy CMP0004.
Call Stack (most recent call first):
  CMakeLists.txt:498 (add_our_library)
```