### PR TITLE
Fix emulation of mouse wheel z position

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -828,6 +828,7 @@ void position_mouse_z(int z)
       return;
 
    _mouse_z = z;
+   al_set_mouse_z(z);
    update_mouse();
 }
 


### PR DESCRIPTION
I've noticed this behavior in an application using allegro-legacy: if you scroll the mouse wheel (any amount) without moving the mouse cursor everything seems to work as expected. But, when you stop scrolling and then just move your mouse, it seems the movement of the mouse emits additional wheel events in the same direction as the last wheel scroll.

I found that adding `al_set_mouse_z(z);` to `position_mouse_z` fixed the issue for me. the a4 program sets the z position to 0 after reading the value (to reset it), but the handling of `ALLEGRO_EVENT_MOUSE_AXES` (a5_mouse.c) undoes this because a5 state doesn't get updated.