### PR TITLE
Define "C" extern block for a5alleg.h

### DIFF
--- a/include/a5alleg.h
+++ b/include/a5alleg.h
@@ -21,10 +21,18 @@
 #ifndef A5_ALLEGRO_LEGACY_H
 #define A5_ALLEGRO_LEGACY_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif 
+
 AL_LEGACY_FUNC(ALLEGRO_DISPLAY *, all_get_display, (void));
 AL_LEGACY_FUNC(ALLEGRO_BITMAP *, all_get_a5_bitmap, (BITMAP * bp));
 AL_LEGACY_FUNC(void, all_render_a5_bitmap, (BITMAP * bp, ALLEGRO_BITMAP * a5bp));
 AL_LEGACY_FUNC(void, all_render_screen, (void));
 AL_LEGACY_FUNC(void, all_disable_threaded_display, (void));
+  
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ifndef A5_ALLEGRO_LEGACY_H */


### PR DESCRIPTION
This is required in order to link to these functions from cpp.