### PR TITLE
Reconfigure joysticks when one connects or disconnects

### DIFF
--- a/src/a5/a5_joystick.c
+++ b/src/a5/a5_joystick.c
@@ -36,6 +36,43 @@ static int a5_get_joystick(ALLEGRO_JOYSTICK * joystick)
     return -1;
 }
 
+static void a5_reconfigure_joysticks()
+{
+    ALLEGRO_JOYSTICK * joystick;
+    int i, j, k;
+
+    num_joysticks = al_get_num_joysticks();
+    for(i = 0; i < num_joysticks; i++)
+    {
+        joystick = al_get_joystick(i);
+        if(joystick)
+        {
+            /* top level */
+            joy[i].flags = JOYFLAG_DIGITAL | JOYFLAG_ANALOGUE;
+
+            /* buttons */
+            joy[i].num_buttons = al_get_joystick_num_buttons(joystick);
+            for(j = 0; j < joy[i].num_buttons; j++)
+            {
+                joy[i].button[j].name = al_get_joystick_button_name(joystick, j);
+            }
+
+            /* sticks */
+            joy[i].num_sticks = al_get_joystick_num_sticks(joystick);
+            for(j = 0; j < joy[i].num_sticks; j++)
+            {
+                joy[i].stick[j].name = al_get_joystick_stick_name(joystick, j);
+                joy[i].stick[j].flags = JOYFLAG_DIGITAL | JOYFLAG_ANALOGUE | JOYFLAG_SIGNED;
+                joy[i].stick[j].num_axis = al_get_joystick_num_axes(joystick, j);
+                for(k = 0; k < joy[i].stick[j].num_axis; k++)
+                {
+                    joy[i].stick[j].axis[k].name = al_get_joystick_axis_name(joystick, j, k);
+                }
+            }
+        }
+    }
+}
+
 static void * a5_joystick_thread_proc(ALLEGRO_THREAD * thread, void * data)
 {
     ALLEGRO_EVENT_QUEUE * queue;
@@ -98,6 +135,11 @@ static void * a5_joystick_thread_proc(ALLEGRO_THREAD * thread, void * data)
                     }
                     break;
                 }
+                case ALLEGRO_EVENT_JOYSTICK_CONFIGURATION:
+                {
+                    a5_reconfigure_joysticks();
+                    break;
+                }
             }
         }
     }
@@ -107,9 +149,6 @@ static void * a5_joystick_thread_proc(ALLEGRO_THREAD * thread, void * data)
 
 static int a5_joystick_init(void)
 {
-    ALLEGRO_JOYSTICK * joystick;
-    int i, j, k;
-
     if(!al_install_joystick())
     {
         return -1;
@@ -120,36 +159,7 @@ static int a5_joystick_init(void)
         al_uninstall_joystick();
         return -1;
     }
-    num_joysticks = al_get_num_joysticks();
-    for(i = 0; i < num_joysticks; i++)
-    {
-        joystick = al_get_joystick(i);
-        if(joystick)
-        {
-            /* top level */
-            joy[i].flags = JOYFLAG_DIGITAL | JOYFLAG_ANALOGUE;
-
-            /* buttons */
-            joy[i].num_buttons = al_get_joystick_num_buttons(joystick);
-            for(j = 0; j < joy[i].num_buttons; j++)
-            {
-                joy[i].button[j].name = al_get_joystick_button_name(joystick, j);
-            }
-
-            /* sticks */
-            joy[i].num_sticks = al_get_joystick_num_sticks(joystick);
-            for(j = 0; j < joy[i].num_sticks; j++)
-            {
-                joy[i].stick[j].name = al_get_joystick_stick_name(joystick, j);
-                joy[i].stick[j].flags = JOYFLAG_DIGITAL | JOYFLAG_ANALOGUE | JOYFLAG_SIGNED;
-                joy[i].stick[j].num_axis = al_get_joystick_num_axes(joystick, j);
-                for(k = 0; k < joy[i].stick[j].num_axis; k++)
-                {
-                    joy[i].stick[j].axis[k].name = al_get_joystick_axis_name(joystick, j, k);
-                }
-            }
-        }
-    }
+    a5_reconfigure_joysticks();
     al_start_thread(a5_joystick_thread);
     return 0;
 }


### PR DESCRIPTION
Joysticks need to be reconfigured whenever one connects or disconnects

This is suggested in the docs for [`al_reconfigure_joysticks`](https://www.allegro.cc/manual/5/al_reconfigure_joysticks), although I'm not called that function but instead re-doing allegro-legacy's josytick data stuctures.

See https://github.com/liballeg/allegro5/pull/1326