### PR TITLE
Simplify implementation of a5_timer

### DIFF
--- a/src/a5/a5_timer.c
+++ b/src/a5/a5_timer.c
@@ -19,238 +19,42 @@
 #include "allegro/internal/aintern.h"
 #include "allegro/platform/ala5.h"
 
-#define _A5_MAX_TIMERS 32
-
-typedef struct
-{
-
-    ALLEGRO_THREAD * thread;
-    ALLEGRO_TIMER * timer;
-    void (*timer_proc)(void);
-    void (*param_timer_proc)(void * data);
-    void * data;
-
-} _A5_TIMER_DATA;
-
-static _A5_TIMER_DATA * a5_timer_data[_A5_MAX_TIMERS];
-
-static ALLEGRO_MUTEX * timers_mutex;
-
-static _A5_TIMER_DATA * a5_create_timer_data(void)
-{
-    _A5_TIMER_DATA * timer_data;
-
-    timer_data = malloc(sizeof(_A5_TIMER_DATA));
-    if(timer_data)
-    {
-        memset(timer_data, 0, sizeof(_A5_TIMER_DATA));
-    }
-    return timer_data;
-}
-
-static _A5_TIMER_DATA * a5_get_free_timer_data(void)
-{
-    int i;
-
-    for(i = 0; i < _A5_MAX_TIMERS; i++)
-    {
-        if (a5_timer_data[i] == NULL)
-        {
-            a5_timer_data[i] = a5_create_timer_data();
-            return a5_timer_data[i];
-        }
-
-        if (a5_timer_data[i]->timer_proc == NULL && a5_timer_data[i]->param_timer_proc == NULL)
-        {
-            return a5_timer_data[i];
-        }
-    }
-
-    return NULL;
-}
-
-static void a5_destroy_timer_data(_A5_TIMER_DATA * timer_data)
-{
-    if(timer_data->thread)
-    {
-        al_destroy_thread(timer_data->thread);
-    }
-    if(timer_data->timer)
-    {
-        al_destroy_timer(timer_data->timer);
-    }
-    free(timer_data);
-}
-
-static void * a5_timer_proc(ALLEGRO_THREAD * thread, void * data)
-{
-    ALLEGRO_EVENT_QUEUE * queue;
-    ALLEGRO_EVENT event;
-    ALLEGRO_TIMEOUT timeout;
-    double cur_time, prev_time = 0.0, diff_time;
-    _A5_TIMER_DATA * timer_data = (_A5_TIMER_DATA *)data;
-
-    queue = al_create_event_queue();
-    if(!queue)
-    {
-        return NULL;
-    }
-    al_register_event_source(queue, al_get_timer_event_source(timer_data->timer));
-    al_start_timer(timer_data->timer);
-    while(!al_get_thread_should_stop(thread))
-    {
-        al_init_timeout(&timeout, 0.1);
-        if(al_wait_for_event_until(queue, &event, &timeout))
-        {
-            cur_time = al_get_time();
-            diff_time = cur_time - prev_time;
-            prev_time = al_get_time();
-            if(timer_data->param_timer_proc)
-            {
-                timer_data->param_timer_proc(timer_data->data);
-            }
-            else if(timer_data->timer_proc)
-            {
-                timer_data->timer_proc();
-            }
-            _handle_timer_tick(MSEC_TO_TIMER(diff_time * 1000.0));
-        }
-    }
-    al_stop_timer(timer_data->timer);
-    al_destroy_event_queue(queue);
-    return NULL;
-}
-
-static int a5_timer_init(void)
-{
-    timers_mutex = al_create_mutex_recursive();
-    return 0;
-}
-
-static void a5_timer_exit(void)
-{
-    int i;
-
-    for(i = 0; i < _A5_MAX_TIMERS && a5_timer_data[i]; i++)
-    {
-        a5_destroy_timer_data(a5_timer_data[i]);
-    }
-}
+static ALLEGRO_THREAD * a5_timer_thread;
 
 static double a5_get_timer_speed(long speed)
 {
     return (double)speed / (float)TIMERS_PER_SECOND;
 }
 
-static int _a5_timer_install_int(void (*proc)(void), long speed)
+static void * a5_timer_proc(ALLEGRO_THREAD * thread, void * unused)
 {
-    int i;
+    double cur_time, prev_time, diff_time;
 
-    for(i = 0; i < _A5_MAX_TIMERS && a5_timer_data[i]; i++)
+    prev_time = al_get_time();
+    while(!al_get_thread_should_stop(thread))
     {
-        if(proc == a5_timer_data[i]->timer_proc)
-        {
-            al_set_timer_speed(a5_timer_data[i]->timer, a5_get_timer_speed(speed));
-            al_unlock_mutex(timers_mutex);
-            return 0;
+        cur_time = al_get_time();
+        diff_time = cur_time - prev_time;
+        prev_time = cur_time;
+        double delay = a5_get_timer_speed(_handle_timer_tick(MSEC_TO_TIMER(diff_time * 1000.0)));
+        if (delay < .001) {
+            delay = .001;
         }
+        al_rest(delay);
     }
+    return NULL;
+}
 
-    _A5_TIMER_DATA* timer_data = a5_get_free_timer_data();
-    if (!timer_data) return -1;
-    if (!timer_data->thread) timer_data->thread = al_create_thread(a5_timer_proc, timer_data);
-    if (!timer_data->timer) timer_data->timer = al_create_timer(a5_get_timer_speed(speed));
-    else al_set_timer_speed(timer_data->timer, a5_get_timer_speed(speed));
-    if (!timer_data->thread || !timer_data->timer) return -1;
-
-    timer_data->timer_proc = proc;
-    al_start_thread(timer_data->thread);
-    al_start_timer(timer_data->timer);
+static int a5_timer_init(void)
+{
+    a5_timer_thread = al_create_thread(a5_timer_proc, NULL);
+    al_start_thread(a5_timer_thread);
     return 0;
 }
 
-static int a5_timer_install_int(void (*proc)(void), long speed)
+static void a5_timer_exit(void)
 {
-    al_lock_mutex(timers_mutex);
-    int result = _a5_timer_install_int(proc, speed);
-    al_unlock_mutex(timers_mutex);
-    return result;
-}
-
-static void a5_timer_remove_int(void (*proc)(void))
-{
-    int i, j;
-
-    al_lock_mutex(timers_mutex);
-
-    for(i = 0; i < _A5_MAX_TIMERS && a5_timer_data[i]; i++)
-    {
-        if(proc == a5_timer_data[i]->timer_proc)
-        {
-            al_stop_timer(a5_timer_data[i]->timer);
-            a5_timer_data[i]->timer_proc = NULL;
-            break;
-        }
-    }
-
-    al_unlock_mutex(timers_mutex);
-}
-
-static int _a5_timer_install_param_int(void (*proc)(void * data), void * param, long speed)
-{
-    int i;
-
-    for(i = 0; i < _A5_MAX_TIMERS && a5_timer_data[i]; i++)
-    {
-        if(proc == a5_timer_data[i]->param_timer_proc && param == a5_timer_data[i]->data)
-        {
-            a5_timer_data[i]->data = param;
-            al_set_timer_speed(a5_timer_data[i]->timer, a5_get_timer_speed(speed));
-            return 0;
-        }
-    }
-
-    _A5_TIMER_DATA* timer_data = a5_get_free_timer_data();
-    if (!timer_data) return -1;
-    if (!timer_data->thread) timer_data->thread = al_create_thread(a5_timer_proc, timer_data);
-    if (!timer_data->timer) timer_data->timer = al_create_timer(a5_get_timer_speed(speed));
-    else al_set_timer_speed(timer_data->timer, speed);
-    if (!timer_data->thread || !timer_data->timer) return -1;
-
-    timer_data->param_timer_proc = proc;
-    timer_data->data = param;
-    al_start_thread(timer_data->thread);
-    al_start_timer(timer_data->timer);
-
-    return 0;
-}
-
-static int a5_timer_install_param_int(void (*proc)(void * data), void * param, long speed)
-{
-    al_lock_mutex(timers_mutex);
-    int result = _a5_timer_install_param_int(proc, param, speed);
-    al_unlock_mutex(timers_mutex);
-    return result;
-}
-
-static void a5_timer_remove_param_int(void (*proc)(void * data), void * param)
-{
-    int i, j;
-
-    al_lock_mutex(timers_mutex);
-
-    for(i = 0; i < _A5_MAX_TIMERS && a5_timer_data[i]; i++)
-    {
-        if(proc == a5_timer_data[i]->param_timer_proc && param == a5_timer_data[i]->data)
-        {
-            al_stop_timer(a5_timer_data[i]->timer);
-            a5_timer_data[i]->param_timer_proc = NULL;
-            a5_timer_data[i]->data = NULL;
-            break;
-        }
-    }
-
-    al_unlock_mutex(timers_mutex);
+    al_destroy_thread(a5_timer_thread);
 }
 
 static void a5_timer_rest(unsigned int time, void (*callback)(void))
@@ -277,12 +81,12 @@ TIMER_DRIVER timer_allegro5 = {
    "Allegro 5 Timer",		// char *ascii_name;
    a5_timer_init,	// AL_LEGACY_METHOD(int, init, (void));
    a5_timer_exit,	// AL_LEGACY_METHOD(void, exit, (void));
-   a5_timer_install_int, 		// AL_LEGACY_METHOD(int, install_int, (AL_LEGACY_METHOD(void, proc, (void)), long speed));
-   a5_timer_remove_int,		// AL_LEGACY_METHOD(void, remove_int, (AL_LEGACY_METHOD(void, proc, (void))));
-   a5_timer_install_param_int,		// AL_LEGACY_METHOD(int, install_param_int, (AL_LEGACY_METHOD(void, proc, (void *param)), void *param, long speed));
-   a5_timer_remove_param_int,		// AL_LEGACY_METHOD(void, remove_param_int, (AL_LEGACY_METHOD(void, proc, (void *param)), void *param));
-   NULL,		// AL_LEGACY_METHOD(int, can_simulate_retrace, (void));
-   NULL,		// AL_LEGACY_METHOD(void, simulate_retrace, (int enable));
+   NULL, 			// AL_LEGACY_METHOD(int, install_int, (AL_LEGACY_METHOD(void, proc, (void)), long speed));
+   NULL,			// AL_LEGACY_METHOD(void, remove_int, (AL_LEGACY_METHOD(void, proc, (void))));
+   NULL,			// AL_LEGACY_METHOD(int, install_param_int, (AL_LEGACY_METHOD(void, proc, (void *param)), void *param, long speed));
+   NULL,			// AL_LEGACY_METHOD(void, remove_param_int, (AL_LEGACY_METHOD(void, proc, (void *param)), void *param));
+   NULL,			// AL_LEGACY_METHOD(int, can_simulate_retrace, (void));
+   NULL,			// AL_LEGACY_METHOD(void, simulate_retrace, (int enable));
    a5_timer_rest,	// AL_LEGACY_METHOD(void, rest, (long time, AL_LEGACY_METHOD(void, callback, (void))));
 };
 


### PR DESCRIPTION
a4 maintains a single thread for all its timers, and runs provided user functions in series. The current AL timer implementation handles each timer callback in its own thread, which is not ideal for a couple reasons:

1) deviates from a4 (possibly in a way that could result in different execution behavior, although I don't have an example of that occurring)
2) extra threads that require mutexes produces a lot of overhead for a timer-heavy program

This patch removes most of the code in a5_timer.c, and instead replaces it with a single timer coordination thread that calls into a4's timer handling procedure `_handle_timer_tick`. It defers to a4's native handling of timer procs (instead of creating a similar system in a5_timer.c). As there is no need for an a5 timer (we do not need any guarentee such as "this code runs, on average, once per x ms" which is what a5 and a4 timers do w/ their `count` variables), the main a5 timer loop simply rests for a bit between every iteration.

The a4 timer procedure returns with a suggestion on how long to wait before the next call - this is determined by a4 looking at the timer queue and returning the time until the next user function needs to be called. There is a max delay value of 0x8000 timer ticks, which is about 27ms (takes a minute to confirm this, but the key is that `_handle_timer_tick` initializes `new_delay` to that many ticks and only ever assigns a smaller value to it).

In addition to sleeping however long `_handle_timer_tick` suggests, I also added some logic for sleeping _at least_ 1 ms. `_handle_timer_tick` does something like that itself:

```
#ifdef ALLEGRO_LEGACY_WINDOWS
   /* fudge factor to prevent interrupts from coming too close to each other */
   if (new_delay < MSEC_TO_TIMER(1))
      new_delay = MSEC_TO_TIMER(1);
#endif
```

But I found that this wasn't really working for some strange reason - on a 32bit msvc build, `delay` (after going through `a5_get_timer_speed`) is `0.00099984830465788509` seconds, which window's Sleep seems to respond to by not yielding the thread at all, resulting in a `0` double being processed as `diff_time` most iterations and stalling all timers. So I just hardcoded some 0.001 value in the a5 timer loop. 1ms seems small enough to be OK, hopefully no a4 program relies on nanosecond precision for timers. And if they do... that just means their callback will run many times every a5_timer loop.