### PR TITLE
Fix improper usage of mutexes in a5_timer.c

### DIFF
--- a/src/a5/a5_timer.c
+++ b/src/a5/a5_timer.c
@@ -105,6 +105,7 @@ static void * a5_timer_proc(ALLEGRO_THREAD * thread, void * data)
             cur_time = al_get_time();
             diff_time = cur_time - prev_time;
             prev_time = al_get_time();
+            al_lock_mutex(timers_mutex);
             if(timer_data->param_timer_proc)
             {
                 timer_data->param_timer_proc(timer_data->data);
@@ -113,6 +114,7 @@ static void * a5_timer_proc(ALLEGRO_THREAD * thread, void * data)
             {
                 timer_data->timer_proc();
             }
+            al_unlock_mutex(timers_mutex);
             _handle_timer_tick(MSEC_TO_TIMER(diff_time * 1000.0));
         }
     }
@@ -151,7 +153,6 @@ static int _a5_timer_install_int(void (*proc)(void), long speed)
         if(proc == a5_timer_data[i]->timer_proc)
         {
             al_set_timer_speed(a5_timer_data[i]->timer, a5_get_timer_speed(speed));
-            al_unlock_mutex(timers_mutex);
             return 0;
         }
     }


### PR DESCRIPTION
Made a mistake in #30, resulting in random crashes.