### PR TITLE
Use allegro 5 malloc functions instead of calling them directly.

### DIFF
--- a/src/allegro.c
+++ b/src/allegro.c
@@ -695,7 +695,7 @@ void register_trace_handler(int (*handler)(AL_CONST char *msg))
  */
 void *_al_malloc(size_t size)
 {
-   return malloc(size);
+   return al_malloc(size);
 }
 
 
@@ -706,7 +706,7 @@ void *_al_malloc(size_t size)
  */
 void _al_free(void *mem)
 {
-   free(mem);
+   al_free(mem);
 }
 
 
@@ -717,7 +717,7 @@ void _al_free(void *mem)
  */
 void *_al_realloc(void *mem, size_t size)
 {
-   return realloc(mem, size);
+   return al_realloc(mem, size);
 }
 
 


### PR DESCRIPTION
This avoids hitting the debug assertion `__acrt_first_block == header`
in MSVC, which happens because one DLL allocates memory (Allegro 5) and
another frees it (Allegro Legacy). This behavior could be seen through
any usage of the file selector dialog - no matter the action, once
closed it will crash on `_al_free(fext_p)` (the associated allocation
was done via `_al_sane_realloc` which is defined in Allegro 5 but
commented out in Allegro Legacy)
