### PR TITLE
use correct ptr integer type, fixes flood crash on 64 bit

### DIFF
--- a/src/flood.c
+++ b/src/flood.c
@@ -53,7 +53,7 @@ static int flooder(BITMAP *bmp, int x, int y, int src_color, int dest_color)
 {
    FLOODED_LINE *p;
    int left = 0, right = 0;
-   unsigned long addr;
+   uintptr_t addr;
    int c;
 
    /* helper for doing checks in each color depth */


### PR DESCRIPTION
All other usages of `bmp_read_line` use the correct type. This was the only bad one, which results in crashes on 64 bit architectures.