### PR TITLE
Avoid installing timer with 0 frequency in midi_resume

### DIFF
--- a/src/midi.c
+++ b/src/midi.c
@@ -1363,7 +1363,10 @@ void midi_resume(void)
    if (!midifile)
       return;
 
-   install_int_ex(midi_player, midi_timer_speed);
+   if (midi_timer_speed)
+      install_int_ex(midi_player, midi_timer_speed);
+   else
+      play_midi(midifile, midi_loop);
 }
 
 END_OF_FUNCTION(midi_resume);


### PR DESCRIPTION
This resolves bug reports from users we got that amounts to "playing a midi crashes my computer".

We just added a way to load files using the OS native file dialog in our app. This means that the main allegro window loses/regains focus as you select a midi file to play. We also have code in our switch out/in methods to pause and resume midis using `midi_pause` and `midi_resume`.

The problem is that our app started a new midi, so `midifile` is set, and at the same time our `switch_in` callbacks run. Since `midifile` is set, `midi_resume` tries to turn the timer back on at its last frequency, except `midi_player` has never run once yet so `midi_timer_speed` is still 0.

Now, allegro 5 has debug asserts checking for 0 frequency timers, but in release mode it happily follows orders. This results in hard-locking our user's computers requiring them to restart.

I think the fix is simply to call `play_midi` in the case where `midi_timer_speed` is still 0, avoiding the bug from the race condition.