### PR TITLE
Destroy timer event queue along with timer_data

### DIFF
--- a/src/a5/a5_timer.c
+++ b/src/a5/a5_timer.c
@@ -73,6 +73,10 @@ static _A5_TIMER_DATA * a5_get_free_timer_data(void)
 
 static void a5_destroy_timer_data(_A5_TIMER_DATA * timer_data)
 {
+    if (timer_data->wait_queue)
+    {
+        al_destroy_event_queue(timer_data->wait_queue);
+    }
     if(timer_data->thread)
     {
         al_destroy_thread(timer_data->thread);


### PR DESCRIPTION
There is an event queue created in _a5_timer_install_int, however it is never destroyed properly. As a result, timer_data gets deleted while queue destructor in a global clean up is called on invalid freed heap data.

<details>
<summary>Typical stack trace (click me)</summary>

```
 	ntdll.dll!RtlEnterCriticalSection()	Unknown
>	allegro-debug-5.2.dll!_al_mutex_lock(_AL_MUTEX * m) Line 59	C
 	allegro-debug-5.2.dll!_al_event_source_lock(ALLEGRO_EVENT_SOURCE * es) Line 79	C
 	allegro-debug-5.2.dll!_al_event_source_on_unregistration_from_queue(ALLEGRO_EVENT_SOURCE * es, ALLEGRO_EVENT_QUEUE * queue) Line 125	C
 	allegro-debug-5.2.dll!al_unregister_event_source(ALLEGRO_EVENT_QUEUE * queue, ALLEGRO_EVENT_SOURCE * source) Line 198	C
 	allegro-debug-5.2.dll!al_destroy_event_queue(ALLEGRO_EVENT_QUEUE * queue) Line 128	C
 	allegro-debug-5.2.dll!_al_run_destructors(_AL_DTOR_LIST * dtors) Line 120	C
 	allegro-debug-5.2.dll!al_uninstall_system() Line 325	C
 	alleg44-debug.dll!a5_sys_exit() Line 38	C
 	alleg44-debug.dll!allegro_exit() Line 475	C
 	alleg44-debug.dll!allegro_exit_stub() Line 294	C
 	mathtest.exe!_execute_onexit_table::__l2::<lambda>() Line 206	C++
 	mathtest.exe!__crt_seh_guarded_call<int>::operator()<void <lambda>(void),int <lambda>(void) &,void <lambda>(void)>(__acrt_lock_and_call::__l2::void <lambda>(void) && setup, _execute_onexit_table::__l2::int <lambda>(void) & action, __acrt_lock_and_call::__l2::void <lambda>(void) && cleanup) Line 204	C++
 	mathtest.exe!__acrt_lock_and_call<int <lambda>(void)>(const __acrt_lock_id lock_id, _execute_onexit_table::__l2::int <lambda>(void) && action) Line 974	C++
 	mathtest.exe!_execute_onexit_table(_onexit_table_t * table) Line 231	C++
 	mathtest.exe!common_exit::__l2::<lambda>() Line 227	C++
 	mathtest.exe!__crt_seh_guarded_call<void>::operator()<void <lambda>(void),void <lambda>(void) &,void <lambda>(void)>(__acrt_lock_and_call::__l2::void <lambda>(void) && setup, common_exit::__l2::void <lambda>(void) & action, __acrt_lock_and_call::__l2::void <lambda>(void) && cleanup) Line 224	C++
 	mathtest.exe!__acrt_lock_and_call<void <lambda>(void)>(const __acrt_lock_id lock_id, common_exit::__l2::void <lambda>(void) && action) Line 974	C++
 	mathtest.exe!common_exit(const int return_code, const _crt_exit_cleanup_mode cleanup_mode, const _crt_exit_return_mode return_mode) Line 259	C++
 	mathtest.exe!exit(int return_code) Line 294	C++
 	[External Code]	
```
</details>

<details>
<summary>EOF stack trace (click me)</summary>

```
…
win_dialog D         win_dialog.c:764  menu_callback                    [   6.33400] Got the WM_SIZE event.
--------8<-------- Wanna quit ?dialog ---------->8------
dtor     D               dtor.c:196  _al_register_destructor          [   6.34006] added dtor for timer 000001CE3D642FA0, func 00007FFADA821050
dtor     D               dtor.c:196  _al_register_destructor          [   6.34030] added dtor for queue 000001CE500CA500, func 00007FFADA821C53
dtor     D               dtor.c:196  _al_register_destructor          [   9.02354] added dtor for queue 000001CE500CBA40, func 00007FFADA821C53
--------------------------------------------------------------------------------- timer wait_queue ^^^
…
audio-dsound I           dsound.cpp:310  _dsound_close                    [  19.12027] DirectSound closed
dtor     D               dtor.c:116  _al_run_destructors              [  24.07458] calling dtor for queue 000001CE500CBA40, func 00007FFADA821C53
dtor     D               dtor.c:227  _al_unregister_destructor        [  24.07488] removed dtor for queue 000001CE500CBA40
**** 0x281C al_unregister_event_source(ALLEGRO_EVENT_QUEUE *, ALLEGRO_EVENT_SOURCE *) 0x0000007aeaeff980 {0x000001ce500cba40 {sources={_itemsize=0x0000000000000008 _items=0x000001ce5050b8d0 {...} ...} ...}}, 0x0000007aeaeff988 {0x000001ce3d641bf0 {__pad=0x000001ce3d641bf0 {0xdddddddd, 0xdddddddd, 0xdddddddd, ...} }}
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- source within freed memory ^^^^
 	allegro-debug-5.2.dll!al_unregister_event_source
	allegro-debug-5.2.dll!al_destroy_event_queue
	allegro-debug-5.2.dll!_al_run_destructors
	allegro-debug-5.2.dll!al_uninstall_system
	alleg44-debug.dll!a5_sys_exit
	alleg44-debug.dll!allegro_exit
	alleg44-debug.dll!allegro_exit_stub
	ucrtbased.dll!00007ffad8262c21
	ucrtbased.dll!00007ffad82623f5
	ucrtbased.dll!00007ffad8262547
	ucrtbased.dll!00007ffad8262e34
	ucrtbased.dll!00007ffad8261cc5
	ucrtbased.dll!00007ffad8261a2d
	ucrtbased.dll!00007ffad8261aa7
	ucrtbased.dll!00007ffad8261e70
	ucrtbased.dll!00007ffad82621f6
	eof.exe!__scrt_common_main_seh
	eof.exe!__scrt_common_main
	eof.exe!WinMainCRTStartup
	kernel32.dll!00007ffc57be53e0
	ntdll.dll!RtlUserThreadStart
	
Exception thrown at 0x00007FFC586FA5ED (ntdll.dll) in eof.exe: 0xC0000005: Access violation reading location 0xFFFFFFFFFFFFFFFF.
```
</details>