### PR TITLE
Fix install_mouse() to return actual button count

### DIFF
--- a/src/a5/a5_mouse.c
+++ b/src/a5/a5_mouse.c
@@ -82,7 +82,8 @@ static int a5_mouse_init(void)
     }
     a5_mouse_thread = al_create_thread(a5_mouse_thread_proc, NULL);
     al_start_thread(a5_mouse_thread);
-    return 0;
+    // Return number of mouse buttons (Allegro 5 typically reports 3)
+    return al_get_mouse_num_buttons();
 }
 
 static void a5_mouse_exit(void)


### PR DESCRIPTION
## Summary

The `a5_mouse_init()` function in the Allegro 5 mouse driver was always returning 0, regardless of how many mouse buttons are actually available.

## Problem

Games that rely on the return value of `install_mouse()` to determine the number of available mouse buttons would incorrectly think no buttons are available. This caused issues when porting Starflight: The Lost Colony to macOS, where the game uses this value to allocate button state arrays.

## Solution

Return `al_get_mouse_num_buttons()` instead of hardcoded 0. This correctly reports:
- 1 button for trackpads
- 3 buttons for standard mice
- The actual count for any other pointing device

## Testing

Tested on macOS with both trackpad and external mouse while porting Starflight: The Lost Colony using Allegro Legacy.